### PR TITLE
Add responsiveness to win/lose modal

### DIFF
--- a/src/components/GuessElement/GuessElement.css
+++ b/src/components/GuessElement/GuessElement.css
@@ -10,6 +10,9 @@
     color: #FFF;
     border-right: 0.4rem solid #151111;
     text-align: center;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .correct {
@@ -40,7 +43,7 @@
 @media (max-width: 800px) {
 
     .ele {
-        font-size: 100%;
+        font-size: 1em;
     }
 
     .country {

--- a/src/components/LosePopup/LosePopup.css
+++ b/src/components/LosePopup/LosePopup.css
@@ -5,4 +5,7 @@
 
 #gator {
     font-weight: 800;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
 }

--- a/src/components/LosePopup/LosePopup.js
+++ b/src/components/LosePopup/LosePopup.js
@@ -27,8 +27,8 @@ export default function LosePopup(props) {
       contentStyle={{
         padding: 0,
         border: 'none',
-        height: '50%',
-        width: '45%',
+        height: 'max(45%, min-content)',
+        width: '60%',
       }}
       modal nested>
       {

--- a/src/components/WinPopup/WinPopup.css
+++ b/src/components/WinPopup/WinPopup.css
@@ -5,4 +5,7 @@
 
 #gator {
     font-weight: 800;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
 }

--- a/src/components/WinPopup/WinPopup.js
+++ b/src/components/WinPopup/WinPopup.js
@@ -27,8 +27,8 @@ export default function WinPopup(props) {
       contentStyle={{
         padding: 0,
         border: 'none',
-        height: '50%',
-        width: '45%',
+        height: 'max(45%, min-content)',
+        width: '60%',
       }}
       modal nested>
       {

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -66,6 +66,12 @@
     cursor: auto;
 }
 
+.header > .ele {
+    overflow-wrap: normal;
+    word-wrap: normal;
+    word-break: normal;
+}
+
 .title-bar {
     width: 100%;
     height: 7rem;

--- a/src/styles/Popup.css
+++ b/src/styles/Popup.css
@@ -58,7 +58,8 @@
 }
 
 @media (max-width: 800px) {
-    .content {
+    #modal-content {
+        margin: 1rem;
         font-size: 200%;
     }
 }


### PR DESCRIPTION
This PR addresses #7 by the following:
- Adds break-word to guess elements.
- Increases width of modal to 60% to ensure styling.
- Sets height of modal to min-content to ensure no vertical overflow